### PR TITLE
Add types for "getters", "rootState" and "rootGetters" inside getters

### DIFF
--- a/src/direct-vuex.ts
+++ b/src/direct-vuex.ts
@@ -24,7 +24,11 @@ export function createDirectStore<
     store,
     rootActionContext: (originalContext: any) => getModuleActionContext(originalContext, options, options),
     moduleActionContext:
-      (originalContext: any, moduleOptions: any) => getModuleActionContext(originalContext, moduleOptions, options)
+      (originalContext: any, moduleOptions: any) => getModuleActionContext(originalContext, moduleOptions, options),
+    rootGetterContext: (state, getters) => getModuleGetterContext(state, getters, state, getters, options, options),
+    moduleGetterContext:
+      (state, getters, rootState, rootGetters, moduleOptions: any) =>
+      getModuleGetterContext(state, getters, rootState, rootGetters, moduleOptions, options)
   }
 }
 
@@ -277,5 +281,34 @@ function getModuleActionContext(
     if (originalContext.state) // Can be undefined in unit tests
       actionContextCache.set(originalContext.state, context)
   }
+  return context
+}
+
+// ModuleContext
+
+const getterContextCache = new WeakMap<any, any>()
+
+function getModuleGetterContext(state: any, getters: any, rootState: any, rootGetters: any, options: ModuleOptions, rootOptions: StoreOptions) {
+  let context = actionContextCache.get(state)
+  // console.log(">> to-actionContext", context ? "FROM_CACHE" : "CREATE", options);
+  if (!context) {
+    context = {
+      get rootState() {
+        return rootState
+      },
+      get rootGetters() {
+        return toDirectGetters(rootOptions, rootGetters)
+      },
+      get state() {
+        return state
+      },
+      get getters() {
+        return toDirectGetters(options, getters)
+      }
+    }
+  if (state) // Can be undefined in unit tests
+    getterContextCache.set(state, context)
+  }
+
   return context
 }

--- a/types/direct-types.d.ts
+++ b/types/direct-types.d.ts
@@ -9,6 +9,13 @@ export interface CreatedStore<R extends StoreOptions> {
     originalContext: ActionContext<any, any>,
     module: O
   ): DirectActionContext<R, O>
+  rootGetterContext: (
+    state: any,
+    getters: any
+  ) => DirectGetterContext<R, R>
+  moduleGetterContext: <O extends ModuleOptions>(
+    state: any, getters: any, rootState: any, rootGetters: any, module: O
+  ) => DirectGetterContext<R, O>
 }
 
 export type ToDirectStore<O extends StoreOptions> = ShowContent<{
@@ -106,6 +113,13 @@ export type DirectActionContext<R, O> = ShowContent<{
   getters: DirectGetters<O>
   commit: DirectMutations<O>
   dispatch: DirectActions<O>
+}>
+
+export type DirectGetterContext<R, O> = ShowContent<{
+  rootState: DirectState<R>
+  rootGetters: DirectGetters<R>
+  state: DirectState<O>
+  getters: DirectGetters<O>
 }>
 
 // Common helpers


### PR DESCRIPTION
For the following getter, only "state" will be typed. All other parameters will be of type "any"

```ts
const mod1 = defineModule({
  …
  getters: {
    p1OrDefault(state, getters, globalState, globalGetters) {
      // "state" is typed but erverything else is "any"
    }
  },
  …
})
```

This commit adds the ability to do the following:

```ts
const mod1 = defineModule({
  …
  getters: {
    p1OrDefault(...args) {
      const { state, getters, rootState, rootGetters } = 
        mod1GetterContext(...args(state, ...args)
      // Now "state", "getters", "rootState" and "rootGetters" are typed
      // and "getters", "rootGetters" can be used as direct getters
    }
  },
  …
})
```

I also changed the readme to explain how the new helper can be used.