### PR TITLE
Changed state and getters to readonly

### DIFF
--- a/types/direct-types.d.ts
+++ b/types/direct-types.d.ts
@@ -35,10 +35,10 @@ type DirectState<O extends StoreOrModuleOptions> =
   & GetStateInModules<OrEmpty<O["modules"]>>
 
 type GetStateInModules<I extends ModulesImpl> = {
-  [M in keyof I]: DirectState<I[M]>
+  readonly [M in keyof I]: DirectState<I[M]>
 }
 
-type ToStateObj<T> = T extends (() => any) ? ReturnType<T> : T
+type ToStateObj<T> = T extends (() => any) ? Readonly<ReturnType<T>> : Readonly<T>
 
 // Getters
 

--- a/types/direct-types.d.ts
+++ b/types/direct-types.d.ts
@@ -50,12 +50,17 @@ type DirectGetters<O extends StoreOrModuleOptions> =
   & MergeGettersFromModules<FilterNotNamespaced<OrEmpty<O["modules"]>>>
 
 type GetGettersInModules<I extends ModulesImpl> = {
-  [M in keyof I]: DirectGetters<I[M]>
+  readonly [M in keyof I]: DirectGetters<I[M]>
 }
 
 type ToDirectGetters<T extends GettersImpl> = {
-  [K in keyof T]: ReturnType<T[K]>
+  readonly [K in keyof T]: ToReadonlyReturnType<T[K]>
 }
+
+type ToReadonlyReturnType<T extends (...args: any) => any> =
+  T extends ((...args1: any) => (...args2: any) => any)
+  ? ReturnType<T>
+  : Readonly<ReturnType<T>>
 
 type MergeGettersFromModules<I extends ModulesImpl> =
   UnionToIntersection<ToDirectGetters<OrEmpty<I[keyof I]["getters"]>>>


### PR DESCRIPTION
https://vuex.vuejs.org/api/#state-2

Since `state` and `getters` are read-only, it would be better if it is typed `readonly`.

```ts
import store from './store'

store.state.flag = false // This will cause error if this PR is merged.
store.getters.flagString = 'no' // Also this will cause error if this PR is merged.
```

Also this PR changes `state` and `getters` in ActionContext and GetterContext to `readonly`.
