### PR TITLE
fix: installing via git didn't trigger build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "types": "types/index.d.ts",
   "scripts": {
     "prepublishOnly": "npm run build && npm run test",
+    "prepare": "npm run build",
     "clear": "rimraf 'build/compiled-*/*'",
     "tsc": "tsc",
     "tsc-es5": "tsc --target ES5 --outDir build/compiled-es5",


### PR DESCRIPTION
This fixes installing via GitHub like so `npm i github:OmgImAlexis/direct-vuex#master`.
Currently when installed the dist directory is missing.

```
➜  frontend git:(main) ✗ tree node_modules/direct-vuex
node_modules/direct-vuex
├── CHANGELOG.txt
├── LICENSE
├── README.md
├── package.json
└── types
    ├── direct-types.d.ts
    └── index.d.ts

1 directory, 6 files
```

After this fix.
```
node_modules/direct-vuex
├── CHANGELOG.txt
├── LICENSE
├── README.md
├── dist
│   ├── direct-vuex.esm.js
│   ├── direct-vuex.esm.min.js
│   ├── direct-vuex.umd.js
│   └── direct-vuex.umd.min.js
├── package.json
└── types
    ├── direct-types.d.ts
    └── index.d.ts

2 directories, 10 files
```